### PR TITLE
Drop better-files dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,6 @@ description   := ""
 bucketSuffix  := "era7.com"
 
 libraryDependencies ++= Seq(
-  "ohnosequences"        %% "cosas"            % "0.8.0",
-  "ohnosequences"        %% "aws-scala-tools"  % "0.18.0",
-  "com.github.pathikrit" %% "better-files"     % "2.13.0",
-  "org.scalatest"        %% "scalatest"        % "2.2.6" % Test
+  "ohnosequences" %% "cosas"           % "0.8.0",
+  "ohnosequences" %% "aws-scala-tools" % "0.18.0"
 )

--- a/src/main/scala/data.scala
+++ b/src/main/scala/data.scala
@@ -2,7 +2,7 @@ package ohnosequences.datasets
 
 import ohnosequences.cosas._, types._, fns._, klists._, records._
 import ohnosequences.awstools.s3._
-import better.files._
+import java.io.File
 
 trait AnyData extends AnyType {
 

--- a/src/main/scala/resources.scala
+++ b/src/main/scala/resources.scala
@@ -1,8 +1,8 @@
 package ohnosequences.datasets
 
 import ohnosequences.cosas._, types._
-import better.files._
 import ohnosequences.awstools.s3._
+import java.io.File
 
 sealed trait AnyDataResource extends Any {
 


### PR DESCRIPTION
This is really not used here. Any `better.files.File` from outside has `.toJava` method. Here this dependency will always cause inconvenience when we want to update better-files in some project depending on datasets (because we need to release it too although no changes are needed here at all).